### PR TITLE
Fix: Education section showing same thesis for all entries

### DIFF
--- a/pages/cv-business.html
+++ b/pages/cv-business.html
@@ -1,145 +1,200 @@
 ---
 layout: page
 title: Business CV
-background: '/img/main/business-cv-bg.jpg'
+background: "/img/main/business-cv-bg.jpg"
 permalink: /business/cv/
-
 ---
 
 <style type="text/css">
+  body {
+    font:
+      18px Helvetica,
+      Sans-Serif;
+    line-height: 24px;
+    background: url(/img/main/noise.jpg);
+  }
+  .clear {
+    clear: both;
+  }
+  #page-wrap {
+    width: 800px;
+    margin: 40px auto 60px;
+  }
+  .cvh1 {
+    margin: 0 0 16px 0;
+    padding: 0 0 16px 0;
+    font-size: 42px;
+    font-weight: bold;
+    letter-spacing: -2px;
+    border-bottom: 1px solid #999;
+    color: #006699;
+  }
+  h2 {
+    font-size: 20px;
+    margin: 0 0 6px 0;
+    position: relative;
+  }
+  h2 span {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    font-style: italic;
+    font-family: Georgia, Serif;
+    font-size: 16px;
+    color: #999;
+    font-weight: normal;
+  }
+  p {
+    margin: 0 0 16px 0;
+  }
+  .job {
+    margin: 0 0 32px 17px;
+  }
+  #objective p {
+    font-family: Georgia, Serif;
+    font-style: italic;
+    color: #333;
+    text-align: justify;
+  }
+  dt {
+    font-style: italic;
+    font-weight: bold;
+    font-size: 18px;
+    text-align: right;
+    padding: 0 26px 0 0;
+    width: 100px;
+    float: left;
+    height: 100px;
+    border-right: 1px solid #999;
+    color: #006699;
+  }
+  dd {
+    width: 670px;
+    float: right;
+  }
+  dd.clear {
+    float: none;
+    margin: 0;
+    height: 15px;
+  }
+  dd strong,
+  dd div h2 {
+    color: #24a49d;
+  }
+  @page {
+    size: A4;
+    margin: 0;
+  }
 
-
-    body { font: 18px Helvetica, Sans-Serif; line-height: 24px; background: url(/img/main/noise.jpg); }
-    .clear { clear: both; }
-    #page-wrap { width: 800px; margin: 40px auto 60px; }
-    .cvh1 { 
-        margin: 0 0 16px 0; 
-        padding: 0 0 16px 0; 
-        font-size: 42px; 
-        font-weight: bold; 
-        letter-spacing: -2px; 
-        border-bottom: 1px solid #999; 
-        color: #006699;
+  @media print {
+    body {
+      width: 210mm;
+      height: 297mm;
+      background-color: #ffffff;
+      background-image: none;
+      color: #000000;
     }
-    h2 { font-size: 20px; margin: 0 0 6px 0; position: relative; }
-    h2 span { position: absolute; bottom: 0; right: 0; font-style: italic; font-family: Georgia, Serif; font-size: 16px; color: #999; font-weight: normal; }
-    p { margin: 0 0 16px 0; }
-    .job { margin: 0 0 32px 17px; }
-    #objective p { font-family: Georgia, Serif; font-style: italic; color: #333; text-align: justify;}
-    dt { 
-        font-style: italic; 
-        font-weight: bold; 
-        font-size: 18px; 
-        text-align: right; 
-        padding: 0 26px 0 0; 
-        width: 100px; 
-        float: left; 
-        height: 100px; 
-        border-right: 1px solid #999;  
-        color:#006699;
+    header,
+    footer {
+      display: none;
     }
-    dd { width: 670px; float: right; }
-    dd.clear { float: none; margin: 0; height: 15px; }
-    dd strong, dd div h2{ 
-        color: #24a49d;
+    #ad {
+      display: none;
     }
-    @page {
-        size: A4;
-        margin: 0;
+    #contentarea {
+      width: 100%;
     }
-
-
-    @media print{
-
-      body{ 
-        width: 210mm;
-    height: 297mm;
-        background-color:#FFFFFF; 
-        background-image:none; 
-        color:#000000 
-    }
-    header, footer{ 
-        display: none;
-    }
-      #ad{ display:none;}
-      #contentarea{ width:100%;}
-    }
-
- </style>
+  }
+</style>
 <div id="page-wrap">
-    <div id="contact-info" class="vcard">    
-        <h1 class="fn cvh1">Polla Fattah</h1>
-        <p>
-            Phone: <span class="tel">+964 (0)750 446 3750</span><br />
-            Email: <a class="email" href="mailto:polla.fattah@gmail.com">polla.fattah@gmail.com</a>
-        </p>
-    </div>
-            
-    <div id="objective">
-        <p>
-            Most of my jobs in bushiness world was a part time/flexible time jobs. 
-            This is due to the nature of my primary job as lecturer at the university as I have a flexible time requirements their.
-            I have been working in the industry for the last 15 years with different companies and various job description. 
-            Nonetheless, I have created a significant trac and participated in many successful projects. 
-            One strong characteristic that I have in the industry is my ability to bring new ideas from academia to the industry.
-        </p>
-    </div>
-    <div class="clear"></div>
-    <dl>
-        <dd class="clear"></dd>
-        
-        <dt>Education</dt>
-        {% for e in site.educations reversed %}
-        <dd>
-            <h2>{{e.establishment}} - {{e.rank}}</h2>
-            <p><strong>Thesis:</strong>Optimizing Rule-based Classification According to Items’ Behavior in Temporal Data<br />
-                <strong>Year:</strong>{{e.start_date | date: '%Y'}}-{{e.end_date | date: '%Y'}}</p>
-        </dd>
-        {% endfor %}
-        <dd class="clear"></dd>
-        <dt>Experience</dt>
-        {% for e in site.data.businessExp reversed %}
-        <dd style="padding: 10px 5px 0px 5px;">
-            <strong>{{e.label}}: </strong> {{ e.explanation }}
-        </dd>
-        {% endfor %}
-        <dd class="clear"></dd>
-        <dt>Skills</dt>
-        <dd>
-            {% for skillSet in site.data.developerSkills %}
-            <div style='text-indent: -60px; margin: 0px 0px 15px 60px'>
-                <strong>  {{ skillSet.skillHead }}: </strong><br />
-                    {% for skill in skillSet.skills %}
-                        {{skill.name}}, 
-                    {% endfor %}
-            </div>
-            {% endfor %}
-        </dd>
-        <dd class="clear"></dd>
-        <dt>Career</dt>
-        <dd>
-        {% for e in site.jobs reversed %}
-        {% if e.category == "business" %}
-            <div class="job">
-                <h2>{{ e.title}} <span>{{ e.organization-short }} - {{ e.start_date }}-{{ e.end_date }}</span></h2>
-                {{ e.duties }}
-            </div>
-        {% endif %}
-        {% endfor %}
-        </dd>
-        <dd class="clear"></dd>
-        <dt>Projects</dt>
-        <dd>
-            {% for e in site.projects reversed %}
-            <div style="display:flex; margin-bottom: 10px;">
-                <strong style="display: inline-block; width:100px;">{{e.date | date:"%b - %Y"}}:</strong>
-                <div style='display: inline-block; width: calc(100% - 115px); '>
-                    {{e.description}}
-                </div>
-            </div>
-            {% endfor %}
-        </dd>
-        <dd class="clear"></dd>
-    </dl>
-    <div class="clear"></div>
+  <div id="contact-info" class="vcard">
+    <h1 class="fn cvh1">Polla Fattah</h1>
+    <p>
+      Phone: <span class="tel">+964 (0)750 446 3750</span><br />
+      Email:
+      <a class="email" href="mailto:polla.fattah@gmail.com"
+        >polla.fattah@gmail.com</a
+      >
+    </p>
+  </div>
+
+  <div id="objective">
+    <p>
+      Most of my jobs in bushiness world was a part time/flexible time jobs.
+      This is due to the nature of my primary job as lecturer at the university
+      as I have a flexible time requirements their. I have been working in the
+      industry for the last 15 years with different companies and various job
+      description. Nonetheless, I have created a significant trac and
+      participated in many successful projects. One strong characteristic that I
+      have in the industry is my ability to bring new ideas from academia to the
+      industry.
+    </p>
+  </div>
+  <div class="clear"></div>
+  <dl>
+    <dd class="clear"></dd>
+
+    <dt>Education</dt>
+    {% for e in site.educations reversed %}
+    <dd>
+      <h2>{{e.establishment}} - {{e.rank}}</h2>
+      <p>
+        <strong>{{e.final_work_label}}:</strong> {{e.final_work}}<br />
+        <strong>Awarding Body:</strong> {{e.establishment}},
+        {{e.awarding_body}}.<br />
+        <strong>Study Years:</strong> {{e.start_date | date: '%Y'}}-{{e.end_date
+        | date: '%Y'}}.
+      </p>
+    </dd>
+    {% endfor %}
+    <dd class="clear"></dd>
+    <dt>Experience</dt>
+    {% for e in site.data.businessExp reversed %}
+    <dd style="padding: 10px 5px 0px 5px">
+      <strong>{{e.label}}: </strong> {{ e.explanation }}
+    </dd>
+    {% endfor %}
+    <dd class="clear"></dd>
+    <dt>Skills</dt>
+    <dd>
+      {% for skillSet in site.data.developerSkills %}
+      <div style="text-indent: -60px; margin: 0px 0px 15px 60px">
+        <strong> {{ skillSet.skillHead }}: </strong><br />
+        {% for skill in skillSet.skills %} {{skill.name}}, {% endfor %}
+      </div>
+      {% endfor %}
+    </dd>
+    <dd class="clear"></dd>
+    <dt>Career</dt>
+    <dd>
+      {% for e in site.jobs reversed %} {% if e.category == "business" %}
+      <div class="job">
+        <h2>
+          {{ e.title}}
+          <span
+            >{{ e.organization-short }} - {{ e.start_date }}-{{ e.end_date
+            }}</span
+          >
+        </h2>
+        {{ e.duties }}
+      </div>
+      {% endif %} {% endfor %}
+    </dd>
+    <dd class="clear"></dd>
+    <dt>Projects</dt>
+    <dd>
+      {% for e in site.projects reversed %}
+      <div style="display: flex; margin-bottom: 10px">
+        <strong style="display: inline-block; width: 100px"
+          >{{e.date | date:"%b - %Y"}}:</strong
+        >
+        <div style="display: inline-block; width: calc(100% - 115px)">
+          {{e.description}}
+        </div>
+      </div>
+      {% endfor %}
+    </dd>
+    <dd class="clear"></dd>
+  </dl>
+  <div class="clear"></div>
 </div>


### PR DESCRIPTION
BUG: On the Business CV page, ALL education entries were displaying the same PhD dissertation text instead of their correct thesis/project information.

CAUSE: Line 95 had hardcoded text instead of using Jekyll template variables.

FIX: Now uses dynamic variables {{e.final_work_label}} and {{e.final_work}} to display the correct information for each education entry:
- PhD: Dissertation
- IT: Final Project
- MSc: Thesis
- BSc: Graduation Project
- Diploma: Major